### PR TITLE
Version models to break cache on a per-model basis

### DIFF
--- a/cachemodel/decorators.py
+++ b/cachemodel/decorators.py
@@ -49,13 +49,16 @@ def denormalized_field(field_name):
     if callable(field_name):
         # we were used without an argument
         raise ArgumentErrror("You must pass a field name to @denormalized_field")
-        
+
     return decorator
 
 def find_fields_decorated_with(instance, property_name):
     """helper function that finds all methods decorated with property_name"""
-    non_field_attributes = set(dir(instance.__class__)) - set(instance._meta.get_all_field_names())
+    klass = instance.__class__
+    if getattr(instance, '_deferred', False):
+        klass = instance._meta.proxy_for_model
+    non_field_attributes = set(dir(klass)) - set(instance._meta.get_all_field_names())
     for m in non_field_attributes:
-        if hasattr(getattr(instance.__class__, m), property_name):
-            yield getattr(instance.__class__, m)
+        if hasattr(getattr(klass, m), property_name):
+            yield getattr(klass, m)
 

--- a/cachemodel/decorators.py
+++ b/cachemodel/decorators.py
@@ -9,7 +9,7 @@ def cached_method(auto_publish=False):
     def decorator(target):
         @wraps(target)
         def wrapper(self, *args, **kwargs):
-            key = generate_cache_key([self.__class__.__name__, target.__name__, self.pk], *args, **kwargs)
+            key = generate_cache_key([self.__class__.__name__, self.model_version, target.__name__, self.pk], *args, **kwargs)
             data = cache.get(key)
             if data is None:
                 data = target(self, *args, **kwargs)

--- a/cachemodel/managers.py
+++ b/cachemodel/managers.py
@@ -6,7 +6,7 @@ from cachemodel.utils import generate_cache_key
 
 class CacheModelManager(models.Manager):
     def get(self, **kwargs):
-        key = generate_cache_key([self.model.__name__, "get"], **kwargs)
+        key = generate_cache_key([self.model.__name__, self.model.model_version, "get"], **kwargs)
         obj = cache.get(key)
         if obj is None:
             obj = super(CacheModelManager, self).get(**kwargs)
@@ -16,7 +16,7 @@ class CacheModelManager(models.Manager):
         return obj
 
     def get_or_create(self, **kwargs):
-        key = generate_cache_key([self.model.__name__, "get"], **kwargs)
+        key = generate_cache_key([self.model.__name__, self.model.model_version, "get"], **kwargs)
         obj = cache.get(key)
         if obj is None:
             return super(CacheModelManager, self).get_or_create(**kwargs)
@@ -39,7 +39,7 @@ class CachedTableManager(models.Manager):
                 self._rebuild_index(field.name)
 
     def _rebuild_index(self, field_name):
-        cache_key = generate_cache_key([self.model.__name__, "table"], field_name)
+        cache_key = generate_cache_key([self.model.__name__, self.model.model_version, "table"], field_name)
         table = {}
         for obj in super(CachedTableManager, self).all().select_related():
             key = getattr(obj, field_name, None)
@@ -49,7 +49,7 @@ class CachedTableManager(models.Manager):
         return table
 
     def _fetch_index(self, field_name):
-        cache_key = generate_cache_key([self.model.__name__, "table"], field_name)
+        cache_key = generate_cache_key([self.model.__name__, self.model.model_version, "table"], field_name)
         table = cache.get(cache_key)
         if table is None:
             table = self._rebuild_index(field_name)

--- a/cachemodel/models.py
+++ b/cachemodel/models.py
@@ -27,6 +27,7 @@ class CacheModel(models.Model):
     """An abstract model that has convienence functions for dealing with caching."""
     objects = models.Manager()
     cached = CacheModelManager()
+    model_version = 1
 
     class Meta:
         abstract = True
@@ -64,7 +65,7 @@ class CacheModel(models.Model):
         kwargs = {}
         for field in args:
             kwargs[field] = getattr(self, field)
-        return generate_cache_key([self.__class__.__name__, "get"], **kwargs)
+        return generate_cache_key([self.__class__.__name__, self.model_version, "get"], **kwargs)
 
     def publish_by(self, *args):
         # cache ourselves, keyed by the fields given
@@ -85,7 +86,7 @@ class CacheModel(models.Model):
             raise AttributeError("method '%s' is not a cached_method.");
         target = getattr(method, '_cached_method_target', None)
         if callable(target):
-            key = generate_cache_key([self.__class__.__name__, target.__name__, self.pk], *args, **kwargs)
+            key = generate_cache_key([self.__class__.__name__, self.model_version, target.__name__, self.pk], *args, **kwargs)
             data = target(self, *args, **kwargs)
             cache.set(key, data, CACHE_FOREVER_TIMEOUT)
 

--- a/cachemodel/models.py
+++ b/cachemodel/models.py
@@ -94,6 +94,7 @@ class CacheModel(models.Model):
 class CachedTable(models.Model):
     objects = models.Manager()
     cached = CachedTableManager()
+    model_version = 1
 
     class Meta:
         abstract = True

--- a/cachemodel/models.py
+++ b/cachemodel/models.py
@@ -40,13 +40,13 @@ class CacheModel(models.Model):
         super(CacheModel, self).save(*args, **kwargs)
 
         # trigger cache publish
-        self.publish()
+        self.publish_to_cache()
 
     def delete(self, *args, **kwargs):
         self.publish_delete("pk")
         super(CacheModel, self).delete(*args, **kwargs)
 
-    def publish(self):
+    def publish_to_cache(self):
         # cache ourselves so that we're ready for .cached.get(pk=)
         self.publish_by('pk')
 

--- a/cachemodel/tests.py
+++ b/cachemodel/tests.py
@@ -132,6 +132,10 @@ class CacheModelTestCase(TestCase):
             self.assertEqual(new_foo.name, new_name)
 
 
+    def test_works_with_deferred(self):
+        """Load a deferred object and verify it saves"""
+        user = Author(first_name='Foo', last_name='foo').save()
+        user = Author.objects.all().only('first_name')
 
-
+        user[0].save()
 

--- a/cachemodel/version.py
+++ b/cachemodel/version.py
@@ -1,1 +1,1 @@
-VERSION = (2, 1, 6)
+VERSION = (2, 1, 7)

--- a/cachemodel/version.py
+++ b/cachemodel/version.py
@@ -1,1 +1,1 @@
-VERSION = (2, 1, 5)
+VERSION = (2, 1, 6)

--- a/tests/test_project/models.py
+++ b/tests/test_project/models.py
@@ -24,8 +24,8 @@ class Author(cachemodel.CacheModel):
     def num_posts(self):
         return self.post_set.all().count()
 
-    def publish(self):
-        super(Author, self).publish()
+    def publish_to_cache(self):
+        super(Author, self).publish_to_cache()
         self.publish_by('first_name','last_name')
 
 
@@ -38,9 +38,9 @@ class Post(cachemodel.CacheModel):
     # category = models.ForeignKey(Category)
 
     # this is to test a child model triggering publishing/denormalizing on a parent
-    def publish(self):
-        super(Post, self).publish()
-        self.author.publish()
+    def publish_to_cache(self):
+        super(Post, self).publish_to_cache()
+        self.author.publish_to_cache()
 
     # this is so we can test @denormalized_field
     @cachemodel.denormalized_field('popularity')
@@ -62,9 +62,9 @@ class Comment(cachemodel.CacheModel):
     created_at = models.DateTimeField(default=datetime.datetime.now)
 
     # this is to test a child model triggering publishing/denormalizing on a parent
-    def publish(self):
-        super(Comment, self).publish()
-        self.post.publish()
+    def publish_to_cache(self):
+        super(Comment, self).publish_to_cache()
+        self.post.publish_to_cache()
 
     # this is to test @cached_method with no parens
     @cachemodel.cached_method

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -1,5 +1,11 @@
 # Django settings for test_project project.
 
+import os
+import sys
+
+PROJECT_ROOT = os.path.realpath(os.path.dirname(__file__) + '/../..')
+sys.path.insert(0, os.path.join(PROJECT_ROOT, ''))
+
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
@@ -140,7 +146,7 @@ import logging
 import sqlparse
 class sqlformatter(logging.Formatter):
     def format(self, record):
-        if record.sql:
+        if hasattr(record, 'sql'):
             return "\n" + sqlparse.format(record.sql, reindent=True, keyword_case="upper") + "\n"
 
 LOGGING = {


### PR DESCRIPTION
Adding a version to the model allows you to increment the version when you're altering a model to prevent objects with stale schemas from being loaded. I don't believe a migration is going to be calling save() on every object and this provides a clean way of resetting cache on a per-model basis. Simply override `model_version` with an integer on your model.
